### PR TITLE
config: exclude unwanted config directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "typeinstall": "bin/typeinstall.js"
   },
   "type": "commonjs",
+  "directories": {
+    "bin": "bin",
+    "lib": "lib"
+  },
   "scripts": {
     "test": "node bin/typeinstall.js express && cat package.json && jest --detectOpenHandles",
     "cli": "node bin/typeinstall.js"


### PR DESCRIPTION
sets the **package.json** config to exclude directories other than the lib and bin﻿
